### PR TITLE
Fix certain minimap buttons to be visible

### DIFF
--- a/objectives/map.lua
+++ b/objectives/map.lua
@@ -172,6 +172,11 @@ local function stackIcons(self, event)
             self.container:Hide()
         end
     end
+    local fnGAT_OnEvent = function(self, event,...)
+        if (event == "PLAYER_ENTERING_WORLD") then
+            stackIcons()
+        end
+    end
     fmGAT:SetScript("OnClick", fnGAT_OnClick)
     fmGAT:SetScript("OnUpdate", function(self)
         if Minimap:IsShown() then
@@ -183,6 +188,9 @@ local function stackIcons(self, event)
             self:SetScript("OnClick", nil)
         end
     end)
+    fmGAT:SetScript("OnEvent", fnGAT_OnEvent)
+    fmGAT:RegisterEvent("PLAYER_ENTERING_WORLD")
+    
     GwAddonToggle:SetPoint("TOPRIGHT", Minimap, "TOPLEFT", -5.5, -127)
     _G["GwAddonToggleTexture"]:SetTexCoord(0, 0.5, 0, 0.25)
 


### PR DESCRIPTION
Found out that the creation of the leatrix minimap button occures after the gw2 minimap bag creation so i used the `PLAYER_ENTERING_WORLD` event to call the `stackIcons()` function again.

If listening on that event is a shitty idea feel free to close this PR.
Goes with this Issue: https://wow.curseforge.com/projects/gw2-ui/issues/212

Off Topic:
After looking through this function and the rest of the file i think that this function needs some refactoring to be done (extract the creation of the button and hiding icons/updating toggle frame, function and variable names etc.) if you want i can take a look on that and update this PR or make a new one with the changes.

PS: This is my first time editing wow addons but you did a great job and this is my way to say thanks
