### PR TITLE
Increase specDesc y to allow full spec description

### DIFF
--- a/character/talents.xml
+++ b/character/talents.xml
@@ -99,7 +99,7 @@
                             </Anchors>
                         </FontString>
                         <FontString parentKey="specDesc" text="Arcane" justifyH="LEFT">
-                            <Size x="400" y="50"></Size>
+                            <Size x="400" y="60"></Size>
                             <Anchors>
                                 <Anchor point="TOPLEFT" relativeKey="$parent.specTitle" relativePoint="BOTTOMLEFT" x="0" y="-5"></Anchor>
                             </Anchors>


### PR DESCRIPTION
By increasing "specDesc" to y 60 from y 50, it allows the full specialization description to be displayed.

Specifically, what it cuts off is what types of weapons the spec uses.

Otherwise, it just leaves "..." after the initial description.

This fixes that.