### PR TITLE
Remove re-enabling of Blizz combat text

### DIFF
--- a/GW2_ui.lua
+++ b/GW2_ui.lua
@@ -544,8 +544,6 @@ local function loadAddon(self)
     if GetSetting("GW_COMBAT_TEXT_ENABLED") then
         SetCVar("floatingCombatTextCombatDamage", 0)
         GW.LoadDamageText()
-    else
-        SetCVar("floatingCombatTextCombatDamage", 1)
     end
 
     if GetSetting("CASTINGBAR_ENABLED") then


### PR DESCRIPTION
If you disable the GW2 combat text it forces Blizzard's default combat text to enable. This conflicts with other floating damage text mods that also disable it.

Also, I believe Blizzard's floating combat text is disabled by default, so there's no need to force enable it when disabling GW2's combat text.