### PR TITLE
Don't match partial ignores that also have LibDBIcon in the name

### DIFF
--- a/objectives/minimapButtons.lua
+++ b/objectives/minimapButtons.lua
@@ -80,7 +80,7 @@ local function SkinMinimapButton(button)
 	end
 
 	for i = 1, #partialIgnore do
-		if strfind(name, partialIgnore[i]) ~= nil then return end
+		if strfind(name, "LibDBIcon") == nil and strfind(name, partialIgnore[i]) ~= nil then return end
 	end
 
     for i = 1, button:GetNumRegions() do


### PR DESCRIPTION
This was incorrectly filtering out a minimap button I had that had the word Note in it. (it was my handynotes minimap icon)