### PR TITLE
Export GetTimeInfo Into GW Namespace

### DIFF
--- a/core/cooldowns.lua
+++ b/core/cooldowns.lua
@@ -31,6 +31,7 @@ local function GetTimeInfo(s)
         return TimeFormats[0]:format(ceil(s / DAY)), days > 1 and (s - (days * DAY - HALFDAYISH)) or (s - DAYISH)
     end
 end
+GW.GetTimeInfo = GetTimeInfo
 
 local function Cooldown_IsEnabled(self)
     if self.forceEnabled then


### PR DESCRIPTION
```
Message: Interface/AddOns/GW2_UI/core/auras.lua:352: attempt to call field 'GetTimeInfo' (a nil value)
Time: Tue Jan 17 19:57:31 2023
Count: 5194
Stack: Interface/AddOns/GW2_UI/core/auras.lua:352: attempt to call field 'GetTimeInfo' (a nil value)
[string "=[C]"]: in function `GetTimeInfo'
[string "@Interface/AddOns/GW2_UI/core/auras.lua"]:352: in function <Interface/AddOns/GW2_UI/core/auras.lua:348>
```