### PR TITLE
Fix Missing Changelog Types Error

### DIFF
--- a/changelog.lua
+++ b/changelog.lua
@@ -7,6 +7,7 @@ local ct = {
   change=3,
 }
 
+GW.CHANGELOGS_TYPES = ct
 
 addChange("2.2.5",{
     {ct.bug,[=[Fix target frame damage number setting]=]},


### PR DESCRIPTION
An error with how the panel overview loads changelog icons was preventing the addon from loading correctly. Added the `CHANGELOG_TYPES` definition to the global `GW` variable to fix this error.