### PR TITLE
Pass frame into customEventHandler

### DIFF
--- a/core/Immersive/chatframe.lua
+++ b/core/Immersive/chatframe.lua
@@ -1722,7 +1722,7 @@ end
 GW.ChatFrame_SystemEventHandler = ChatFrame_SystemEventHandler
 
 local function ChatFrame_OnEvent(frame, ...)
-    if frame.customEventHandler and frame.customEventHandler(...) then return end
+    if frame.customEventHandler and frame.customEventHandler(frame, ...) then return end
 
     if ChatFrame_ConfigEventHandler(frame, ...) then return end
     if ChatFrame_SystemEventHandler(frame, ...) then return end


### PR DESCRIPTION
You made an oopsie when implementing the customEventHandler, where arg1 needs to be the frame, much like the other chat handler events.