### PR TITLE
fix (TBC): prevent nil error in stats.lua

### DIFF
--- a/TBC/Character/stats.lua
+++ b/TBC/Character/stats.lua
@@ -69,7 +69,11 @@ local function getPrimary(i, unit)
 
     -- Get class specific tooltip for that stat
     local _, classFileName = UnitClass(unit)
-    local classStatText = _G[strupper(classFileName) .. "_" .. PRIMARY_STATS[i] .. "_" .. "TOOLTIP"]
+    local classStatText
+    
+    if classFileName then
+        classStatText = _G[strupper(classFileName) .. "_" .. PRIMARY_STATS[i] .. "_" .. "TOOLTIP"]
+    end
 
     -- If can't find one use the default
     if not classStatText then


### PR DESCRIPTION
This PR fixes a Lua error occurring in the Character Stats module specifically in the TBC Classic version of the addon.

Error log:
Version: GW2_UI 10.6.0 Date: 03/27/26 02:53:00 Locale: enUS Build 2.5.5 66567
[02:51:11] [ERROR]: "GW2_UI/TBC/Character/stats.lua:72: bad argument #1 to 'strupper' (string expected, got nil)"
[C]: in function 'strupper'
[GW2_UI/TBC/Character/stats.lua]:72: in function 'getPrimary'
[GW2_UI/TBC/Character/character.lua]:376: in function 'PaperDollUpdatePetStats'
[GW2_UI/TBC/Character/character.lua]:126: in function <GW2_UI/TBC/Character/character.lua:101>