### PR TITLE
Update quest IDs for Legends of the Haranir event

### DIFF
--- a/Games/Mainline/Immersive/eventTracker.lua
+++ b/Games/Mainline/Immersive/eventTracker.lua
@@ -215,6 +215,7 @@ local eventData = {
                 [WeeklyName(7385004, L["Legend"], 2413)] = {
                     -- https://www.wowhead.com/npc=238170/zurashar-kassameh#ends
                     89268,
+					92713,
                 },
                 [WeeklyName(7636650, L["Abundance"], 2437)] = {
                     -- https://www.wowhead.com/quest=89507/abundant-offerings


### PR DESCRIPTION
After all 7 relics have been completed on a character, a different quest is offered instead. Added this ID to the relevant section. https://www.wowhead.com/quest=92713/echoes-rekindled