### PR TITLE
Fix 12.1 secret value errors across tooltips, unit frames, chat, class power and guild data

### DIFF
--- a/Games/Shared/DataInfo/guild.lua
+++ b/Games/Shared/DataInfo/guild.lua
@@ -90,7 +90,17 @@ local function FetchGuildMembers_Internal()
             end
         end
 
-        local members = guildClubID and CommunitiesUtil.GetAndSortMemberInfo(guildClubID)
+        -- GetAndSortMemberInfo starts with C_Club.GetClubMembers and feeds the result straight
+        -- into ipairs. That table is secret while club data is restricted, and ipairs rejects it
+        -- with "table expected, got secret" from inside Blizzard's code, where we cannot guard
+        -- it - so check the same call ourselves before handing the club id over.
+        local members
+        if guildClubID then
+            local memberIds = C_Club.GetClubMembers(guildClubID)
+            if memberIds and GW.NotSecretValue(memberIds) and GW.NotSecretTable(memberIds) then
+                members = CommunitiesUtil.GetAndSortMemberInfo(guildClubID)
+            end
+        end
         if members then
             for _, data in next, members do
                 if data.guid then

--- a/Games/Shared/Immersive/chatframe.lua
+++ b/Games/Shared/Immersive/chatframe.lua
@@ -185,11 +185,18 @@ local function AdjustChatLines(frame)
     for index, fontString in ipairs(visibleLines) do
         if index == 1 then
             local point, relativeTo, relativePoint, _, yOfs = fontString:GetPoint(1)
+            -- GetPoint is flagged SecretWhenAnchoringSecret, so a line that inherits secret
+            -- anchoring hands back secret values, and SetPoint rejects secret arguments with a
+            -- usage error. A secret string is still truthy, so the completeness check below
+            -- lets it through. Leave the anchor as the engine set it in that case - the call
+            -- would have failed anyway, and SetWidth below still does the real work.
+            local anchorIsSecret = GW.IsSecretValue(point) or GW.IsSecretValue(relativeTo)
+                or GW.IsSecretValue(relativePoint) or GW.IsSecretValue(yOfs)
             -- only rebuild the anchor when GetPoint handed back a complete one: a line
             -- that the engine has not anchored yet (fresh out of the pool while the dock
             -- switches tabs) reports no relative point, and passing that nil on to
             -- SetPoint makes it reject the whole argument list
-            if point and relativePoint and (relativeTo or fontString:GetParent() ~= nil) then
+            if not anchorIsSecret and point and relativePoint and (relativeTo or fontString:GetParent() ~= nil) then
                 -- an explicit parent is what a nil relativeTo means anyway, and it keeps
                 -- SetPoint from having to guess at a nil in the middle of the arguments
                 fontString:SetPoint(point, relativeTo or fontString:GetParent(), relativePoint, -offset, yOfs or 0)

--- a/Games/Shared/Immersive/tooltips.lua
+++ b/Games/Shared/Immersive/tooltips.lua
@@ -102,6 +102,8 @@ end
 
 local function SetUnitAura(self, unit, index, filter)
     if not self or self:IsForbidden() or self:NumLines() < 1 then return end
+    -- reading aura data raises an error for tainted code while auras are restricted
+    if GW.AurasAreSecret() then return end
 
     local auraData = C_UnitAuras.GetAuraDataByIndex(unit, index, filter)
     if not auraData then return end
@@ -114,6 +116,7 @@ local function SetUnitAuraByAuraInstanceId(self, unit, auraInstanceId)
     -- callers like the CooldownViewer pass secret instance IDs — reading the aura
     -- data would be denied for tainted code
     if GW.IsSecretValue(auraInstanceId) or GW.IsSecretValue(unit) then return end
+    if GW.AurasAreSecret() then return end
 
     local auraData = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, auraInstanceId)
     if not auraData then return end
@@ -587,6 +590,10 @@ local function AddTargetInfo(self, unit)
 end
 
 local function AddMountInfo(self, unit)
+    -- GetBuffDataByIndex errors outright for tainted code while aura access is restricted.
+    -- The caller's InCombatLockdown() check does not cover encounters, keys or PvP matches.
+    if GW.AurasAreSecret() then return end
+
     local index = 1
     local auraData = C_UnitAuras.GetBuffDataByIndex(unit, index)
     while auraData do

--- a/Games/Shared/Immersive/tooltips.lua
+++ b/Games/Shared/Immersive/tooltips.lua
@@ -955,6 +955,96 @@ local function GameTooltip_SetDefaultAnchor(self, parent)
     end
 end
 
+-- ISOLATED TEST. Widget setup reads secret text metrics (GetStringHeight and friends) and does
+-- arithmetic on them, which throws under our taint. The mixins involved are shared across the
+-- whole widget system, so the only place we may touch is this tooltip scoped entry point.
+--
+-- An earlier attempt reverted alongside a GameTooltip_InsertFrame rewrite that broke world quest
+-- tooltips, and the two were never told apart. This adds back only the wrapper. If the completion
+-- percentage survives, the wrapper was innocent; if it disappears, this is the culprit and goes.
+-- Blizzard_SharedXML/SharedTooltipTemplates.lua's GameTooltip_InsertFrame, with exactly one line
+-- moved: frame:GetWidth() is read before the frame is re-anchored instead of after.
+--
+-- Anchoring the frame into a tooltip line is what turns its measurements secret. Proof from a
+-- single failing call: neededHeight came back as a plain 80 from frame:GetHeight() before the
+-- re-anchor, while frameWidth from the same frame after it was secret. Reading the width early
+-- gets a real number, so the minimum width bump below happens exactly as Blizzard intended.
+--
+-- Nothing else changes. The comparison stays unguarded on purpose: a container that was already
+-- parented to the tooltip (the widget container never leaves it) still reports a secret width and
+-- still throws here, precisely as it does with Blizzard's own version - and that path is known to
+-- render fine. An earlier attempt guarded the comparison and skipped the bump instead, which left
+-- the tooltip too narrow to show its inserted frame and quietly broke world quest tooltips.
+local function GwGameTooltip_InsertFrame(tooltipFrame, frame, verticalPadding)
+    verticalPadding = verticalPadding or 0
+
+    local textSpacing = tooltipFrame:GetCustomLineSpacing() or 2
+    local textHeight = Round(tooltipFrame:GetLeftLine(2):GetLineHeight())
+    local neededHeight = Round(frame:GetHeight() + verticalPadding)
+    local frameWidth = frame:GetWidth() -- moved up: still measurable while unanchored
+    local numLinesNeeded = math.ceil(neededHeight / (textHeight + textSpacing))
+    local currentLine = tooltipFrame:NumLines()
+
+    GameTooltip_AddBlankLinesToTooltip(tooltipFrame, numLinesNeeded)
+    frame:SetParent(tooltipFrame)
+    frame:ClearAllPoints()
+    frame:SetPoint("TOPLEFT", tooltipFrame:GetLeftLine(currentLine + 1), "TOPLEFT", 0, -verticalPadding)
+
+    if not tooltipFrame.insertedFrames then
+        tooltipFrame.insertedFrames = {}
+    end
+
+    if tooltipFrame:GetMinimumWidth() < frameWidth then
+        tooltipFrame:SetMinimumWidth(frameWidth)
+    end
+
+    frame:Show()
+    tinsert(tooltipFrame.insertedFrames, frame)
+
+    -- return space taken so inserted frame can resize if needed
+    return (numLinesNeeded * textHeight) + (numLinesNeeded - 1) * textSpacing
+end
+
+local function GuardTooltipWidgetSets()
+    local BlizzardAddWidgetSet = GameTooltip_AddWidgetSet
+    if BlizzardAddWidgetSet then
+        function GameTooltip_AddWidgetSet(self, widgetSetID, verticalPadding)
+            local ok, heightUsed = pcall(BlizzardAddWidgetSet, self, widgetSetID, verticalPadding)
+            if ok then return heightUsed end
+        end
+    end
+
+    local BlizzardClearWidgetSet = GameTooltip_ClearWidgetSet
+    if BlizzardClearWidgetSet then
+        function GameTooltip_ClearWidgetSet(self)
+            pcall(BlizzardClearWidgetSet, self)
+        end
+    end
+end
+
+-- The suppressed pin container lays out cloned map pins (FrameCloneManager), whose anchoring is
+-- secret, so ResizeLayoutMixin:Layout throws while walking them. Its own mixin is applied after
+-- ResizeLayoutMixin, so defining Layout here overrides it for this one frame type and nothing
+-- else - never guard ResizeLayoutMixin itself, that drags our taint into every layout frame.
+--
+-- The cloned pins cannot be measured either way, so that list stays invisible. What containment
+-- buys is the rest of the tooltip: AddCustomTooltipData adds a header before each section and
+-- loops over several of them, so an escaping error leaves a bare header with nothing under it and
+-- drops both the remaining sections and the trailing instruction line.
+local function GuardSuppressedPinTooltipLayout()
+    if not SuppressedPinTooltipContainerMixin or SuppressedPinTooltipContainerMixin.Layout then return end
+    if not ResizeLayoutMixin or not ResizeLayoutMixin.Layout then return end
+
+    local BlizzardLayout = ResizeLayoutMixin.Layout
+    SuppressedPinTooltipContainerMixin.Layout = function(self)
+        -- probe first so a container that is itself secret keeps its previous size instead of
+        -- being reset to 1x1 by the SetSize at the top of Blizzard's layout
+        if GW.IsSecretValue(self:GetNumPoints()) then return end
+
+        pcall(BlizzardLayout, self)
+    end
+end
+
 local function SetTooltipFonts()
     local font = UNIT_NAME_FONT
     local fontOutline = ""
@@ -1266,6 +1356,27 @@ local function LoadTooltips()
     hooksecurefunc("GameTooltip_SetDefaultAnchor", GameTooltip_SetDefaultAnchor)
 
     if GW.Retail then
+        GuardTooltipWidgetSets()
+
+        if GameTooltip_InsertFrame then
+            GameTooltip_InsertFrame = GwGameTooltip_InsertFrame
+        end
+
+        -- Blizzard_SharedMapDataProviders is load on demand; the container is not built until a
+        -- pin is hovered, which is always later than the addon load, so this is early enough.
+        if C_AddOns.IsAddOnLoaded("Blizzard_SharedMapDataProviders") then
+            GuardSuppressedPinTooltipLayout()
+        else
+            local mapProviderWaitFrame = CreateFrame("Frame")
+            mapProviderWaitFrame:RegisterEvent("ADDON_LOADED")
+            mapProviderWaitFrame:SetScript("OnEvent", function(_, _, addonName)
+                if addonName == "Blizzard_SharedMapDataProviders" then
+                    GuardSuppressedPinTooltipLayout()
+                    mapProviderWaitFrame:UnregisterAllEvents()
+                end
+            end)
+        end
+
         GameTooltipDefaultContainer:GwKillEditMode()
 
         if not GW.ShouldBlockIncompatibleAddon("LfgInfo") then

--- a/Games/Shared/Objectives/ObjectivesTracker.lua
+++ b/Games/Shared/Objectives/ObjectivesTracker.lua
@@ -300,6 +300,22 @@ end
 
 local function DisableBlizzardsObjevtiveTracker()
     if GW.Retail then
+        -- Taking the tracker over taints Blizzard's update path, and their scenario module keeps
+        -- running on it regardless. ShouldShowMawBuffs reads player auras from there, which is a
+        -- hard error for tainted code while aura access is restricted, so every scenario layout
+        -- pass throws. Degrade to the zone check the original already ORs in - it is only ever
+        -- used to decide whether the maw buff block is shown, never for a protected action.
+        if ShouldShowMawBuffs then
+            local BlizzardShouldShowMawBuffs = ShouldShowMawBuffs
+            function ShouldShowMawBuffs()
+                if GW.AurasAreSecret() then
+                    return IsInJailersTower() or false
+                end
+
+                return BlizzardShouldShowMawBuffs()
+            end
+        end
+
         ObjectiveTrackerFrame:Hide()
         ObjectiveTrackerFrame:UnregisterAllEvents()
         ObjectiveTrackerFrame:SetScript("OnUpdate", nil)

--- a/Games/Shared/Units/Classpower/shared.lua
+++ b/Games/Shared/Units/Classpower/shared.lua
@@ -18,6 +18,9 @@ local function HandleUnitAuraEvent(unit, ...)
     local debuffsChanged = false
     local dataTable = unit == "pet" and petAuras or unit == "player" and playerAuras or nil
     if not dataTable then return end
+    -- Skipping only costs us a refresh: while aura access is restricted every lookup below
+    -- would raise an error instead of returning data, so there is nothing to read either way.
+    if GW.AurasAreSecret() then return end
 
     if isFullUpdate then
         table.wipe(dataTable.buffs)
@@ -385,7 +388,8 @@ local function GetAuraData(unit, unitSource, filter, ...)
                 results[#results + 1] = auraData
             end
         end
-    elseif unitSource and filter == "HARMFUL" then
+    -- the index scan below reads another unit's debuffs, which errors while auras are restricted
+    elseif unitSource and filter == "HARMFUL" and not GW.AurasAreSecret() then
         for i = 1, 40 do
             local auraData = C_UnitAuras.GetDebuffDataByIndex(unit, i)
 

--- a/Games/Shared/Units/unitframes.lua
+++ b/Games/Shared/Units/unitframes.lua
@@ -367,14 +367,18 @@ function GwUnitFrameMixin:SetUnitPortraitFrame()
             end
         elseif self.showItemLevel == "PVP_LEVEL" then
             local honorLevel = GW.Retail and UnitHonorLevel(unit) or 0
-            local prestigeLevel = (honorLevel > 199 and 4) or (honorLevel > 99 and 3) or
-                                (honorLevel > 49 and 2) or (honorLevel > 9 and 1) or 0
 
+            -- UnitHonorLevel is secret while unit identity is restricted, and comparing a
+            -- secret number errors out. Skip the prestige border/text instead of blowing up.
+            if GW.NotSecretValue(honorLevel) then
+                local prestigeLevel = (honorLevel > 199 and 4) or (honorLevel > 99 and 3) or
+                                    (honorLevel > 49 and 2) or (honorLevel > 9 and 1) or 0
 
-            if prestigeLevel > 0 and TARGET_FRAME_ART["prestige" .. prestigeLevel] then
-                border = "prestige" .. prestigeLevel
+                if prestigeLevel > 0 and TARGET_FRAME_ART["prestige" .. prestigeLevel] then
+                    border = "prestige" .. prestigeLevel
+                end
+                txt = honorLevel
             end
-            txt = honorLevel
         end
     end
 

--- a/core/API/api.lua
+++ b/core/API/api.lua
@@ -188,7 +188,11 @@ local function SetAlphaRecursive(frame, alpha)
     -- skip forbidden subtrees (e.g. AuraContainer buttons) — SetAlpha would error
     -- there; their effective alpha follows the accessible parent anyway
     if frame.IsForbidden and frame:IsForbidden() then return end
-    frame:SetAlpha(alpha)
+    -- IsForbidden does not catch all of it on 12.x: an AuraContainer button reports false and
+    -- still rejects the call with "Attempt to access forbidden object from code tainted by an
+    -- AddOn". Give up on the whole subtree when that happens, since walking its children would
+    -- fail the same way, and the alpha we cannot set is only a fade.
+    if not pcall(frame.SetAlpha, frame, alpha) then return end
 
     local numChildren = frame:GetNumChildren()
     if numChildren == 0 then

--- a/core/init.lua
+++ b/core/init.lua
@@ -218,6 +218,21 @@ do
     function GW.UnitNotUnit(unit1, unit2) -- nil means blocked
         return GW.UnitIsUnit(unit1, unit2) == false
     end
+
+    -- 12.0: aura APIs flagged "RequiresUnitAuraAccess" (GetAuraSlots, GetAuraDataBySlot,
+    -- GetBuffDataByIndex, ...) raise a hard Lua error - not a nil return - when aura data is
+    -- secret and execution is tainted by an addon. The restriction is active during combat,
+    -- encounters, challenge mode and PvP matches, so an InCombatLockdown() check is not enough.
+    local ShouldAurasBeSecret = C_Secrets and C_Secrets.ShouldAurasBeSecret
+
+    function GW.AurasAreSecret()
+        if not ShouldAurasBeSecret then return false end -- no secret system (Classic and friends)
+
+        local ok, isSecret = pcall(ShouldAurasBeSecret)
+        if not ok then return true end -- unable to tell, assume the worst
+
+        return isSecret == true
+    end
 end
 
 


### PR DESCRIPTION
Fixes for the 12.1 secret value errors, all reproduced and running in game on 11.1.2 / 12.1.0 (69299) for several days. Analysis and full stacks are in #274.

## How this is organised

The first seven commits touch only GW2_UI's own code. Each is a few lines, each changes nothing unless the call would have errored outright, and each is independent — cherry-pick freely.

| | |
|---|---|
| `GW.AurasAreSecret` helper | `C_Secrets.ShouldAurasBeSecret`, false where the system does not exist |
| Tooltip aura lookups | `AddMountInfo`, `SetUnitAura`, `SetUnitAuraByAuraInstanceId` |
| Class power aura lookups | `HandleUnitAuraEvent`, live via the paladin holy power bar |
| `UnitHonorLevel` | secret number reaching a comparison from ordinary target cycling |
| Chat line anchors | `GetPoint` returning secret values into `SetPoint` |
| `SetAlphaRecursive` | `IsForbidden` misses AuraContainer buttons on 12.x |
| Guild member fetch | `C_Club.GetClubMembers` returning a secret table into `ipairs` |

The last two commits work around errors raised **inside Blizzard's own code**, where no GW2_UI frame appears in the stack at all. They are deliberately last so they can be dropped without disturbing anything above, and I would understand entirely if you prefer your own approach there.

## The one thing worth reading even if you take none of this

Every layout error on the tooltip path lands on the same line, `ResizeLayoutMixin:Layout` comparing `GetNumPoints()`, so guarding that mixin looks like it fixes the whole class at once.

**It does not.** The mixin is copied into hundreds of unrelated frames, nameplates among them, and because the layout writes back through `SetSize`, those frames stay tainted afterwards. Blizzard's nameplate code then started failing to measure its restricted regions, to index its forbidden crowd control aura list, and to compare secret health values — none of which it had any trouble with before. Same trap applies to `DefaultWidgetLayout` and `UIWidgetContainerMixin`.

Two rules came out of that, and everything here follows both:

1. Only patch a symbol whose callers are already on a tainted path. Never one that Blizzard's own clean frames share.
2. Never change behaviour on a path that was not already erroring. A guard may turn an error into a clean skip; it must not turn working code into code that does less.

Rule 2 has teeth: an early version of the `GameTooltip_InsertFrame` fix guarded the comparison and skipped the minimum width bump. The error stopped, and world quest tooltips quietly lost their completion percentage, because the tooltip was never widened to hold its inserted frame. The version here moves the width read above the re-anchor instead, so the bump still happens — verified in game.

## Not everything is fixable from out here

`ContinuableContainer:CheckIfSatisfied` runs its callback under `xpcall(callbackFunction, CallErrorHandler)`, so the item display widget errors are reported by Blizzard's handler and never propagate. No outer wrapper can suppress those; they would need a fix inside the widget mixins, which rule 1 puts out of reach. They appear to be harmless — Blizzard contains them and the widget just keeps its default size.

Happy to split this up, drop the last two commits, or rework anything to taste.

---

For anyone finding this from an error report before it lands: these are on [`local-fixes`](https://github.com/kyaky/GW2_UI/tree/local-fixes) in my fork, kept rebased on the current release.
