### PR TITLE
Three secret value guards still missing on develop

### DIFF
--- a/Games/Mainline/Character/paperdoll_equipment.lua
+++ b/Games/Mainline/Character/paperdoll_equipment.lua
@@ -358,7 +358,12 @@ end
 local function stat_OnEnter(self)
     if (not self.tooltip) then
         if self.onEnterFunc and not InCombatLockdown() then
-            self.onEnterFunc(self)
+            -- Blizzard's stat handlers do arithmetic on values that are secret while stats are
+            -- restricted - Mastery_OnEnter feeds GetMasteryEffect() straight into
+            -- GetSecondaryBonus, which multiplies it. That throws from inside their code where
+            -- we cannot guard it, and the only thing lost is a tooltip that was not going to
+            -- render anyway.
+            pcall(self.onEnterFunc, self)
         end
         return
     end

--- a/Games/Shared/DataInfo/guild.lua
+++ b/Games/Shared/DataInfo/guild.lua
@@ -90,7 +90,16 @@ local function FetchGuildMembers_Internal()
             end
         end
 
-        local members = guildClubID and CommunitiesUtil.GetAndSortMemberInfo(guildClubID)
+        -- GetAndSortMemberInfo opens with C_Club.GetClubMembers and feeds the result straight
+        -- into ipairs, which throws "table expected, got secret" from inside Blizzard's helper
+        -- where we cannot guard it, so make the same call ourselves first
+        local members
+        if guildClubID then
+            local memberIds = C_Club.GetClubMembers(guildClubID)
+            if memberIds and GW.NotSecretValue(memberIds) and GW.NotSecretTable(memberIds) then
+                members = CommunitiesUtil.GetAndSortMemberInfo(guildClubID)
+            end
+        end
         if members then
             for _, data in next, members do
                 if data.guid then

--- a/Games/Shared/Immersive/tooltips.lua
+++ b/Games/Shared/Immersive/tooltips.lua
@@ -587,6 +587,10 @@ local function AddTargetInfo(self, unit)
 end
 
 local function AddMountInfo(self, unit)
+    -- GetBuffDataByIndex errors outright while aura access is restricted, and SetUnitInfo only
+    -- gates this on InCombatLockdown(), which does not cover encounters, keys or PvP matches
+    if GW.AreAurasSecret() then return end
+
     local index = 1
     local auraData = C_UnitAuras.GetBuffDataByIndex(unit, index)
     while auraData do

--- a/Games/Shared/Units/Classpower/shared.lua
+++ b/Games/Shared/Units/Classpower/shared.lua
@@ -18,6 +18,9 @@ local function HandleUnitAuraEvent(unit, ...)
     local debuffsChanged = false
     local dataTable = unit == "pet" and petAuras or unit == "player" and playerAuras or nil
     if not dataTable then return end
+    -- every lookup below is one of the RequiresUnitAuraAccess APIs, so while the restriction is
+    -- in effect they cannot return data either way - this trades an error for a skipped refresh
+    if GW.AreAurasSecret() then return end
 
     if isFullUpdate then
         table.wipe(dataTable.buffs)


### PR DESCRIPTION
Rebased onto `develop` after your reply on #274 — you were right, most of what I reported is already fixed there. I went through my patches one by one against `develop` and these three are what survived.

| | |
|---|---|
| `AddMountInfo` | `SetUnitAura` and `SetUnitAuraByAuraInstanceId` both got `GW.AreAurasSecret()`; this one did not, and `SetUnitInfo` only gates it on `InCombatLockdown()` |
| `HandleUnitAuraEvent` | four `RequiresUnitAuraAccess` calls, reachable on retail through the paladin holy power bar |
| `FetchGuildMembers_Internal` | `C_Club.GetClubMembers` returns a secret table straight into Blizzard's `ipairs` |

All three use your helpers rather than introducing anything new. 17 lines total.

Closes #275, which was built against `master` before I knew about `develop` and duplicated work you had already done.

## Things I had patched that `develop` already handles

Noting these so you know they are covered and I am not sitting on divergent versions: the `GW.AreAurasSecret` helper itself, `SetUnitAura`, `SetUnitAuraByAuraInstanceId`, `UnitHonorLevel` in `SetUnitPortraitFrame`, and the secret anchor values in `AdjustChatLines`.

`SetAlphaRecursive` too — and your version is better than mine. I had reached for `pcall` because `IsForbidden()` returns false on those buttons; skipping the subtree on `GetObjectType() == "AuraContainer"` avoids ever touching the forbidden child, which is the cleaner answer.
